### PR TITLE
FIX: 주문 생성 시 Importancy-key를 통한 중복주문 방지, 주문 취소 시 주문에 대한 비관적 락 추가 #17

### DIFF
--- a/src/main/java/com/sorryisme/fmarket/annotation/IdempotencyKeyParam.java
+++ b/src/main/java/com/sorryisme/fmarket/annotation/IdempotencyKeyParam.java
@@ -1,0 +1,11 @@
+package com.sorryisme.fmarket.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IdempotencyKeyParam {
+}

--- a/src/main/java/com/sorryisme/fmarket/annotation/Idempotent.java
+++ b/src/main/java/com/sorryisme/fmarket/annotation/Idempotent.java
@@ -1,0 +1,11 @@
+package com.sorryisme.fmarket.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Idempotent {
+}

--- a/src/main/java/com/sorryisme/fmarket/aop/IdempotencyAspect.java
+++ b/src/main/java/com/sorryisme/fmarket/aop/IdempotencyAspect.java
@@ -23,7 +23,6 @@ public class IdempotencyAspect {
     private final IdempotencyKeyMapper idempotencyKeyMapper;
 
     @Around("@annotation(com.sorryisme.fmarket.annotation.Idempotent)")
-    @Transactional
     public Object handleIdempotency(ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
@@ -55,10 +54,9 @@ public class IdempotencyAspect {
         if (idempotencyKey == null)  throw new IllegalArgumentException("Idempotency-Key 헤더가 필요합니다.");
         if (idempotencyKey.length() != 36) throw new IllegalArgumentException("idempotencyKey 키는 36자리여야 합니다.");
 
-        boolean isExistIdempotencyKey = idempotencyKeyMapper.isExistIdempotencyKeyForUpdate(idempotencyKey);
-        if(isExistIdempotencyKey) throw new DuplicateDataException("중복된 요청입니다.");
+        int result = idempotencyKeyMapper.insertIgnoreIdempotencyKey(idempotencyKey);
+        if (result <= 0) throw new DuplicateDataException("중복된 요청입니다.");
 
-        idempotencyKeyMapper.insertIdempotencyKey(idempotencyKey);
 
         return joinPoint.proceed();
     }

--- a/src/main/java/com/sorryisme/fmarket/aop/IdempotencyAspect.java
+++ b/src/main/java/com/sorryisme/fmarket/aop/IdempotencyAspect.java
@@ -1,0 +1,65 @@
+package com.sorryisme.fmarket.aop;
+
+
+import com.sorryisme.fmarket.annotation.IdempotencyKeyParam;
+import com.sorryisme.fmarket.exception.DuplicateDataException;
+import com.sorryisme.fmarket.mapper.IdempotencyKeyMapper;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class IdempotencyAspect {
+
+    private final IdempotencyKeyMapper idempotencyKeyMapper;
+
+    @Around("@annotation(com.sorryisme.fmarket.annotation.Idempotent)")
+    @Transactional
+    public Object handleIdempotency(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        
+        Object[] args = joinPoint.getArgs();
+        String idempotencyKey = null;
+
+        Annotation[][] paramAnnotations = method.getParameterAnnotations();
+
+        for (int i = 0; i < paramAnnotations.length; i++) {
+            for (Annotation annotation : paramAnnotations[i]) {
+                if (annotation instanceof IdempotencyKeyParam) {
+                    Object arg = args[i];
+
+                    if (!(arg instanceof String)) {
+                        throw new IllegalArgumentException("Idempotency-Key 파라미터는 String 타입이어야 합니다.");
+                    }
+
+                    idempotencyKey = (String) arg;
+                    break;
+                }
+            }
+
+            if (idempotencyKey != null) {
+                break;
+            }
+        }
+
+        if (idempotencyKey == null)  throw new IllegalArgumentException("Idempotency-Key 헤더가 필요합니다.");
+        if (idempotencyKey.length() != 36) throw new IllegalArgumentException("idempotencyKey 키는 36자리여야 합니다.");
+
+        boolean isExistIdempotencyKey = idempotencyKeyMapper.isExistIdempotencyKeyForUpdate(idempotencyKey);
+        if(isExistIdempotencyKey) throw new DuplicateDataException("중복된 요청입니다.");
+
+        idempotencyKeyMapper.insertIdempotencyKey(idempotencyKey);
+
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/sorryisme/fmarket/controller/OrderController.java
+++ b/src/main/java/com/sorryisme/fmarket/controller/OrderController.java
@@ -12,7 +12,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.jaxb.SpringDataJaxb;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class OrderController {
 
     private final OrderService orderService;
+    private static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
 
 
     @PostMapping("/orders")
@@ -56,8 +56,12 @@ public class OrderController {
 
     @PostMapping("/orders/create")
     @RequireLogin
-    public ResponseDto<Long> createOrder(@LoginUserId Long userId, @RequestBody @Valid OrderCreateDto orderCreateDto) {
-        return ResponseDto.success(orderService.createOrder(userId, orderCreateDto));
+    public ResponseDto<Long> createOrder(
+            @RequestHeader(value = IDEMPOTENCY_KEY_HEADER) String idempotencyKey,
+            @LoginUserId Long userId,
+            @RequestBody @Valid OrderCreateDto orderCreateDto
+    ) {
+        return ResponseDto.success(orderService.createOrder(idempotencyKey, userId, orderCreateDto));
     }
 
 }

--- a/src/main/java/com/sorryisme/fmarket/filter/MDCLoggingFilter.java
+++ b/src/main/java/com/sorryisme/fmarket/filter/MDCLoggingFilter.java
@@ -14,6 +14,7 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 
@@ -42,6 +43,7 @@ public class MDCLoggingFilter implements Filter {
         } finally {
             long processingTime = System.currentTimeMillis() - startTime;
             loggingRequestResponse(wrappedRequest, wrappedResponse, processingTime);
+            wrappedResponse.copyBodyToResponse();
             MDC.clear();
         }
     }
@@ -65,6 +67,7 @@ public class MDCLoggingFilter implements Filter {
                 String.format(">>[USER_AGENT]: %s\n", wrappedRequest.getHeader("User-Agent")) +
                 String.format(">>[REFERER]: %s\n", wrappedRequest.getHeader("Referer")) +
                 String.format(">>[ORIGIN]: %s\n", wrappedRequest.getHeader("Origin")) +
+                String.format(">>[Idempotency-Key]: %s\n", wrappedRequest.getHeader("Idempotency-Key")) +
                 String.format(">>[REMOTE_ADDR]: %s\n", wrappedRequest.getRemoteAddr()) +
                 String.format(">>[REMOTE_HOST]: %s\n", wrappedRequest.getRemoteHost()) +
                 String.format(">>[REQUEST_BODY]: %s\n", getRequestBody(wrappedRequest)) +

--- a/src/main/java/com/sorryisme/fmarket/mapper/IdempotencyKeyMapper.java
+++ b/src/main/java/com/sorryisme/fmarket/mapper/IdempotencyKeyMapper.java
@@ -1,0 +1,20 @@
+
+package com.sorryisme.fmarket.mapper;
+
+import com.sorryisme.fmarket.domain.Cart;
+import com.sorryisme.fmarket.domain.CartDetail;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface IdempotencyKeyMapper {
+
+    @Select("SELECT EXISTS (SELECT id FROM idempotency_keys WHERE idempotency_key = #{idempotencyKey} FOR UPDATE)")
+    boolean isExistIdempotencyKeyForUpdate(String idempotencyKey);
+
+    @Insert("INSERT INTO idempotency_keys(idempotency_key, created_at) values (#{idempotencyKey}, now())")
+    int insertIdempotencyKey(String idempotencyKey);
+
+}

--- a/src/main/java/com/sorryisme/fmarket/mapper/IdempotencyKeyMapper.java
+++ b/src/main/java/com/sorryisme/fmarket/mapper/IdempotencyKeyMapper.java
@@ -14,7 +14,7 @@ public interface IdempotencyKeyMapper {
     @Select("SELECT EXISTS (SELECT id FROM idempotency_keys WHERE idempotency_key = #{idempotencyKey} FOR UPDATE)")
     boolean isExistIdempotencyKeyForUpdate(String idempotencyKey);
 
-    @Insert("INSERT INTO idempotency_keys(idempotency_key, created_at) values (#{idempotencyKey}, now())")
-    int insertIdempotencyKey(String idempotencyKey);
+    @Insert("INSERT IGNORE INTO idempotency_keys(idempotency_key, created_at) values (#{idempotencyKey}, now())")
+    int insertIgnoreIdempotencyKey(String idempotencyKey);
 
 }

--- a/src/main/java/com/sorryisme/fmarket/mapper/OrderMapper.java
+++ b/src/main/java/com/sorryisme/fmarket/mapper/OrderMapper.java
@@ -22,5 +22,6 @@ public interface OrderMapper {
     OrderResponseDto findOrderById(Long orderId);
     int createOrder(Order order);
     int createOrderDetail(List<OrderDetail> orderDetail);
+    OrderResponseDto findOrderByIdForUpdate(Long orderId);
 
 }

--- a/src/main/java/com/sorryisme/fmarket/service/OrderService.java
+++ b/src/main/java/com/sorryisme/fmarket/service/OrderService.java
@@ -1,6 +1,11 @@
 package com.sorryisme.fmarket.service;
 
-import com.sorryisme.fmarket.domain.*;
+import com.sorryisme.fmarket.annotation.IdempotencyKeyParam;
+import com.sorryisme.fmarket.annotation.Idempotent;
+import com.sorryisme.fmarket.domain.Inventory;
+import com.sorryisme.fmarket.domain.Order;
+import com.sorryisme.fmarket.domain.OrderDetail;
+import com.sorryisme.fmarket.domain.ProductOption;
 import com.sorryisme.fmarket.dto.request.OrderCreateDto;
 import com.sorryisme.fmarket.dto.request.OrderItemRequestDto;
 import com.sorryisme.fmarket.dto.request.OrderSearchDto;
@@ -17,7 +22,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -29,6 +33,7 @@ public class OrderService {
     private final OrderMapper orderMapper;
     private final InventoryMapper inventoryMapper;
     private final ProductMapper productMapper;
+
 
     public Page<Order> findAllOrderList(OrderSearchDto orderSearchDto) {
         List<Order> orderList = orderMapper.findAllOrderList(orderSearchDto);
@@ -55,11 +60,11 @@ public class OrderService {
     @Transactional
     public Long cancelOrder(Long orderId) {
 
-        OrderResponseDto orderResponseDto = orderMapper.findOrderById(orderId);
+        OrderResponseDto orderResponseDto = orderMapper.findOrderByIdForUpdate(orderId);
 
         if (orderResponseDto == null) throw new NotFoundDataException("찾을 수 없는 주문입니다.");
         if (!OrderStatus.PENDING.getValue().equals(orderResponseDto.getStatus()))
-            throw new IllegalStateException("변경이 불가한 상태입니다");
+            throw new IllegalArgumentException("변경이 불가한 상태입니다");
 
         List<Inventory> orderedInventories = orderResponseDto.getOrderDetails()
                 .stream()
@@ -73,8 +78,9 @@ public class OrderService {
         return orderId;
     }
 
+    @Idempotent
     @Transactional
-    public Long createOrder(Long userId, OrderCreateDto orderCreateDto) {
+    public Long createOrder(@IdempotencyKeyParam String idempotencyKey, Long userId, OrderCreateDto orderCreateDto) {
 
         // 1. 주문 생성
         List<ProductOption> productOptions = getProductOptions(orderCreateDto.getOrderItems());

--- a/src/main/resources/mapper/OrderMapper.xml
+++ b/src/main/resources/mapper/OrderMapper.xml
@@ -91,6 +91,24 @@
         </foreach>
     </insert>
 
-
+    <select id="findOrderByIdForUpdate" resultMap="orderMap">
+        SELECT
+            o.id,
+            o.user_id,
+            o.status,
+            o.total_amount,
+            o.order_date,
+            o.created_at,
+            o.updated_at,
+            od.id AS detail_id,
+            od.product_option_id,
+            od.quantity,
+            od.price,
+            od.created_at AS detail_created_at,
+            od.updated_at AS detail_updated_at
+        FROM `ORDER` o
+                 LEFT JOIN `ORDER_DETAIL` od ON (o.id = od.order_id)
+        WHERE o.id = #{orderId} FOR UPDATE
+    </select>
 
 </mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,6 +11,7 @@ DROP TABLE IF EXISTS `order`;
 DROP TABLE IF EXISTS `product_option`;
 DROP TABLE IF EXISTS `product`;
 DROP TABLE IF EXISTS `user`;
+DROP TABLE IF EXISTS `idempotency_keys`;
 
 CREATE TABLE `user` (
   `id` bigint NOT NULL AUTO_INCREMENT,
@@ -186,4 +187,11 @@ CREATE TABLE `cart_detail` (
   PRIMARY KEY (`id`),
   CONSTRAINT `cart_detail_ibfk_1` FOREIGN KEY (`cart_id`) REFERENCES `cart` (`id`) ON DELETE CASCADE,
   CONSTRAINT `cart_detail_ibfk_2` FOREIGN KEY (`product_option_id`) REFERENCES `product_option` (`id`) ON DELETE CASCADE
+);
+
+CREATE TABLE `idempotency_keys` (
+  `id` int primary key auto_increment,
+  `idempotency_key` CHAR(36),
+  `created_at` datetime(6),
+   INDEX idx_idempotency_key(idempotency_key)
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -190,8 +190,8 @@ CREATE TABLE `cart_detail` (
 );
 
 CREATE TABLE `idempotency_keys` (
-  `id` int primary key auto_increment,
-  `idempotency_key` CHAR(36),
+  `id` bigint primary key auto_increment,
+  `idempotency_key` CHAR(36) unique,
   `created_at` datetime(6),
    INDEX idx_idempotency_key(idempotency_key)
 );

--- a/src/test/groovy/com/sorryisme/fmarket/mapper/IdempotencyKeyMapperTest.groovy
+++ b/src/test/groovy/com/sorryisme/fmarket/mapper/IdempotencyKeyMapperTest.groovy
@@ -17,26 +17,15 @@ class IdempotencyKeyMapperTest extends Specification {
 
     private static final String UUID = "166f9067-2e5f-4932-e314-f438ae846d24"
 
-    def "UUID가 제공되면 정상적으로 INSERT된다"() {
+    def "같은 UUID로 2번 INSERT 시 첫번째만 저장되고 두번 째는 무시된다"() {
 
         when:
-        int result = idempotencyKeyMapper.insertIdempotencyKey(UUID)
+        int expectedInsert = idempotencyKeyMapper.insertIgnoreIdempotencyKey(UUID)
+        int expectedIgnore = idempotencyKeyMapper.insertIgnoreIdempotencyKey(UUID)
 
         then:
-        result > 0
-
-    }
-
-    def "UUID가 조회가 되면 true를 리턴한다"() {
-
-        given:
-        idempotencyKeyMapper.insertIdempotencyKey(UUID);
-
-        when:
-        boolean isExistIdempotencyKey = idempotencyKeyMapper.isExistIdempotencyKeyForUpdate(UUID);
-
-        then:
-        isExistIdempotencyKey
+        expectedInsert > 0
+        expectedIgnore <= 0
 
     }
 

--- a/src/test/groovy/com/sorryisme/fmarket/mapper/IdempotencyKeyMapperTest.groovy
+++ b/src/test/groovy/com/sorryisme/fmarket/mapper/IdempotencyKeyMapperTest.groovy
@@ -1,0 +1,43 @@
+package com.sorryisme.fmarket.mapper
+
+
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+@MybatisTest
+@ContextConfiguration
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class IdempotencyKeyMapperTest extends Specification {
+
+    @Autowired
+    private IdempotencyKeyMapper idempotencyKeyMapper
+
+    private static final String UUID = "166f9067-2e5f-4932-e314-f438ae846d24"
+
+    def "UUID가 제공되면 정상적으로 INSERT된다"() {
+
+        when:
+        int result = idempotencyKeyMapper.insertIdempotencyKey(UUID)
+
+        then:
+        result > 0
+
+    }
+
+    def "UUID가 조회가 되면 true를 리턴한다"() {
+
+        given:
+        idempotencyKeyMapper.insertIdempotencyKey(UUID);
+
+        when:
+        boolean isExistIdempotencyKey = idempotencyKeyMapper.isExistIdempotencyKeyForUpdate(UUID);
+
+        then:
+        isExistIdempotencyKey
+
+    }
+
+}

--- a/src/test/groovy/com/sorryisme/fmarket/service/OrderServiceTest.groovy
+++ b/src/test/groovy/com/sorryisme/fmarket/service/OrderServiceTest.groovy
@@ -32,6 +32,8 @@ class OrderServiceTest extends Specification {
     List<ProductOption> productOptions
     List<Inventory> inventories
 
+    private static final String UUID = "166f9067-2e5f-4932-e314-f438ae846d24"
+
     def setup() {
         orderCreateDto = new OrderCreateDto([
                 new OrderItemRequestDto(1L, 3),
@@ -178,7 +180,7 @@ class OrderServiceTest extends Specification {
         inventoryMapper.updateStockQuantity(_ as List<Inventory> ) >> 2
 
         when:
-        orderService.createOrder(1L, orderCreateDto)
+        orderService.createOrder(UUID, 1L, orderCreateDto)
 
         then:
         1 * orderMapper.createOrder(_)
@@ -195,7 +197,7 @@ class OrderServiceTest extends Specification {
         inventoryMapper.updateStockQuantity(_ as List<Inventory> ) >> 2
 
         when:
-        orderService.createOrder(1L, orderCreateDto)
+        orderService.createOrder(UUID, 1L, orderCreateDto)
 
         then:
         def e = thrown(IllegalArgumentException.class)

--- a/src/test/groovy/com/sorryisme/fmarket/service/OrderServiceTest.groovy
+++ b/src/test/groovy/com/sorryisme/fmarket/service/OrderServiceTest.groovy
@@ -124,7 +124,7 @@ class OrderServiceTest extends Specification {
         Long orderId = 1L
         OrderResponseDto orderResponseDto = createOrderResponseDto()
 
-        orderMapper.findOrderById(orderId) >> orderResponseDto
+        orderMapper.findOrderByIdForUpdate(orderId) >> orderResponseDto
         inventoryMapper.findStockQuantityForUpdate(_ as List<Inventory>) >> [Mock(Inventory)]
         inventoryMapper.increaseStockQuantity(_ as Inventory) >> 1
         orderMapper.updateOrder(orderId, OrderStatus.CANCELLED.getValue()) >> 1
@@ -139,7 +139,7 @@ class OrderServiceTest extends Specification {
     def "주문취소 시 주문이 없을 경우 에러를 발생시킨다"() {
         given:
         Long orderId = 1L
-        orderMapper.findOrderById(orderId) >> null
+        orderMapper.findOrderByIdForUpdate(orderId) >> null
 
         when:
         orderService.cancelOrder(orderId)
@@ -155,13 +155,13 @@ class OrderServiceTest extends Specification {
         OrderResponseDto orderResponseDto = Mock()
         orderResponseDto.getStatus() >> OrderStatus.COMPLETED.getValue()
 
-        orderMapper.findOrderById(orderId) >> orderResponseDto
+        orderMapper.findOrderByIdForUpdate(orderId) >> orderResponseDto
 
         when:
         orderService.cancelOrder(orderId)
 
         then:
-        def e = thrown(IllegalStateException.class)
+        def e = thrown(IllegalArgumentException.class)
         e.getMessage() == "변경이 불가한 상태입니다"
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#17 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

멀티스레드 환경에서 동시에 여러 개의 요청이 들어왔을 때 다음 로직에서 문제가 발생

1. 주문 취소하기 -> (재고 연속 증가)
2. 주문하기 -> (중복 주문 발생)

다음과 같이 해결하고자 했습니다.

1. [주문 취소] 
- 주문 취소 시 주문에 조회에 대한 비관적 락 추가

2. [주문 하기] 
- 주문 시 중복 주문방지를 위해 Idempotency-key를 통한 방지 기능
- 다른 부분에서 공용으로 사용하기 위해서 스프링 AOP와 애노테이션을 통한 idempotencyKey 검증

관련하여 테스트 진행 결과에 대한 링크는 다음과 같습니다
1. https://chartreuse-timbale-782.notion.site/f-market-17f766ae4fdf803ab565c5d4e3c9dfdf?pvs=73
